### PR TITLE
Also lint Javascript ERB files

### DIFF
--- a/lib/pronto/eslint_npm.rb
+++ b/lib/pronto/eslint_npm.rb
@@ -35,7 +35,7 @@ module Pronto
     end
 
     def js_file?(path)
-      %w(.js .es6 .js.es6).include?(File.extname(path))
+      path.to_s =~ /(\.js|\.es6|\.js\.es6)(\.erb)?$/
     end
 
     def run_eslint(patch)


### PR DESCRIPTION
In our company we use a lot of `.js.es6.erb` files.

This pull request takes the optional `.erb` extension into account for Javascript files.