### PR TITLE
Load YAML configuration correctly

### DIFF
--- a/lib/pronto/eslint_npm.rb
+++ b/lib/pronto/eslint_npm.rb
@@ -4,7 +4,7 @@ require 'shellwords'
 module Pronto
   class ESLintNpm < Runner
     CONFIG_FILE = '.pronto_eslint_npm.yml'.freeze
-    CONFIG_KEYS = %i(eslint_executable files_to_lint).freeze
+    CONFIG_KEYS = %w(eslint_executable files_to_lint).freeze
 
     attr_writer :eslint_executable
 

--- a/spec/pronto/eslint_spec.rb
+++ b/spec/pronto/eslint_spec.rb
@@ -39,7 +39,7 @@ module Pronto
 
         context(
           'with files to lint config that never matches',
-          config: { files_to_lint: 'will never match' }
+          config: { 'files_to_lint' => 'will never match' }
         ) do
           it 'returns zero errors' do
             expect(run.count).to eql(0)
@@ -48,7 +48,7 @@ module Pronto
 
         context(
           'with files to lint config that matches only .js',
-          config: { files_to_lint: /\.js/ }
+          config: { 'files_to_lint' => /\.js/ }
         ) do
           it 'returns correct amount of errors' do
             expect(run.count).to eql(2)
@@ -57,7 +57,7 @@ module Pronto
 
         context(
           'with different eslint executable',
-          config: { eslint_executable: './custom_eslint.sh' }
+          config: { 'eslint_executable' => './custom_eslint.sh' }
         ) do
           it 'calls the custom eslint eslint_executable' do
             expect { run }.to raise_error(JSON::ParserError, /custom eslint called/)


### PR DESCRIPTION
Use strings when fetching YAML config. Indeed, when loading a YAML file, keys are strings, not symbols. Example:

```ruby
require 'yaml'
config = YAML.load_file('.pronto_eslint_npm.yml') #=> { "files_to_lint" => "my_value" }
config[:files_to_lint] #=> nil
config['files_to_lint'] #=> "my_value"
```