### PR TITLE
Remove rake dependency in gemspec

### DIFF
--- a/pronto-eslint_npm.gemspec
+++ b/pronto-eslint_npm.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0.0'
   s.rubygems_version = '1.8.23'
 
-  s.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  s.files = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(lib/|(LICENSE|README.md)$)}) }
   s.extra_rdoc_files = ['LICENSE', 'README.md']
   s.require_paths = ['lib']
   s.requirements << 'eslint (in PATH)'

--- a/pronto-eslint_npm.gemspec
+++ b/pronto-eslint_npm.gemspec
@@ -2,7 +2,6 @@
 
 $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 require 'pronto/eslint_npm/version'
-require 'rake'
 
 Gem::Specification.new do |s|
   s.name = 'pronto-eslint_npm'
@@ -19,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0.0'
   s.rubygems_version = '1.8.23'
 
-  s.files = FileList['LICENSE', 'README.md', 'lib/**/*']
+  s.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   s.extra_rdoc_files = ['LICENSE', 'README.md']
   s.require_paths = ['lib']
   s.requirements << 'eslint (in PATH)'


### PR DESCRIPTION
This removes the dependancy on rake in the gemspec file. We were running into an error during bundling our main app:

```bash

[!] There was an error while loading `pronto-eslint_npm.gemspec`: cannot load such file -- rake
Does it try to require a relative path? That's been removed in Ruby 1.9. Bundler cannot continue.

 #  from .../vendor/bundle/ruby/2.4.0/bundler/gems/pronto-eslint_npm-31779f86de71/pronto-eslint_npm.gemspec:5
 #  -------------------------------------------
 #  require 'pronto/eslint_npm/version'
 >  require 'rake'
 #  
 #  -------------------------------------------
```

The git command was lifted from `bundle gem new_gem_name`