### PR TITLE
Map eslint's severity to pronto's levels

### DIFF
--- a/lib/pronto/eslint_npm.rb
+++ b/lib/pronto/eslint_npm.rb
@@ -7,6 +7,7 @@ module Pronto
   class ESLintNpm < Runner
     CONFIG_FILE = '.pronto_eslint_npm.yml'.freeze
     CONFIG_KEYS = %w[eslint_executable files_to_lint cmd_line_opts].freeze
+    SEVERITY_LEVELS = [nil, :warning, :error].freeze
 
     attr_writer :eslint_executable, :cmd_line_opts
 
@@ -72,7 +73,7 @@ module Pronto
 
     def new_message(offence, line)
       path  = line.patch.delta.new_file[:path]
-      level = :warning
+      level = SEVERITY_LEVELS.fetch(offence['severity'], :warning)
 
       Message.new(path, line, level, offence['message'], nil, self.class)
     end

--- a/spec/pronto/eslint_spec.rb
+++ b/spec/pronto/eslint_spec.rb
@@ -53,7 +53,7 @@ module Pronto
 
         it 'has correct levels' do
           expect(run.map(&:level)).to eql([
-            :warning, :warning, :warning, :warning, :warning, :warning, :warning
+            :error, :error, :warning, :error, :error, :error, :error
           ])
         end
 


### PR DESCRIPTION
This will pass the severity level from eslint over to pronto. The commit is stacked on top of #11 to be able to use some of the spec improvements and because the `no-multiple-empty-lines` is set to warn which makes testing this easier.