### PR TITLE
Fix the markdown formatting in the table

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Following options are available:
 | Option            | Meaning                                                                                  | Default                             |
 | ----------------- | ---------------------------------------------------------------------------------------- | ----------------------------------- |
 | eslint_executable | ESLint executable to call.                                                               | `eslint` (calls `eslint` in `PATH`) |
-| files_to_lint     | What files to lint. Absolute path of offending file will be matched against this Regexp. | `(\.js|\.es6)$`                     |
+| files_to_lint     | What files to lint. Absolute path of offending file will be matched against this Regexp. | `(\.js\|\.es6)$`                    |
 | cmd_line_opts     | Command line options to pass to eslint when running                                      | ''                                  |
 
 Example configuration to call custom eslint executable and only lint files ending with `.my_custom_extension`:


### PR DESCRIPTION
To render correctly on GitHub it seems to need the pipe to be escaped otherwise it seems to see it as the end of the table.

<img width="911" alt="Screenshot 2019-05-14 09 06 00" src="https://user-images.githubusercontent.com/68750/57708998-81809300-7627-11e9-86e3-f0b1b852f0dd.png">

If you wanted to keep it copy/pasteable for plan text users looking at file in an editor it might be best to just remove it from the table. and switch to a bulleted list.