### PR TITLE
run eslint in parallel

### DIFF
--- a/lib/pronto/eslint_npm.rb
+++ b/lib/pronto/eslint_npm.rb
@@ -2,6 +2,7 @@
 
 require 'pronto'
 require 'shellwords'
+require 'parallel'
 
 module Pronto
   class ESLintNpm < Runner
@@ -47,11 +48,12 @@ module Pronto
 
       read_config
 
-      @patches
+      patches = @patches
         .select { |patch| patch.additions > 0 }
         .select { |patch| js_file?(patch.new_file_full_path) }
-        .map { |patch| inspect(patch) }
-        .flatten.compact
+
+      Parallel.flat_map(patches, in_threads: Parallel.processor_count) { |p| inspect(p) }
+        .compact
     end
 
     private

--- a/pronto-eslint_npm.gemspec
+++ b/pronto-eslint_npm.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.requirements << 'eslint (in PATH)'
 
   s.add_dependency('pronto', '~> 0.11.0')
+  s.add_dependency('parallel', '~> 1.20.1')
   s.add_development_dependency('rake', '>= 11.0', '< 13')
   s.add_development_dependency('rspec', '~> 3.4')
 end

--- a/pronto-eslint_npm.gemspec
+++ b/pronto-eslint_npm.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.requirements << 'eslint (in PATH)'
 
   s.add_dependency('pronto', '~> 0.11.0')
-  s.add_dependency('parallel', '~> 1.20.1')
+  s.add_dependency('parallel', '~> 1.14')
   s.add_development_dependency('rake', '>= 11.0', '< 13')
   s.add_development_dependency('rspec', '~> 3.4')
 end


### PR DESCRIPTION
If you touch a lot of files, then it can take some time to run eslint sequentially for each changed file. By parallelizing it with multiple threads, it can work through them faster. I measured about a ~6x increase in performance for about ~250 files changed.